### PR TITLE
Update europe.yaml

### DIFF
--- a/data/europe.yaml
+++ b/data/europe.yaml
@@ -95,7 +95,11 @@
    type: school
    long: -0.886867
    lat: 41.681891
- - name: Karlsruhe Institute of Technology
+ - name: iralab, Dept. Informatica, Sistemistica e Comunicazione; Università di Milano - Bicocca
+   type: school
+   long: 9.219541
+   lat: 45.523715
+- name: Karlsruhe Institute of Technology
    type: school
    long: 8.417019
    lat: 49.012142


### PR DESCRIPTION
added iralab entry (after "Instituto Tecnologico de Aragon" and before "Karlsruhe Institute of Technology")