### PR TITLE
Yaml testing using Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,5 @@ script:
   - yamllint data/australia.yaml
   - yamllint data/europe.yaml
   - python generate_kml.py data/africa.yaml data/america.yaml data/asia.yaml data/australia.yaml data/europe.yaml
+notifications:
+  email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,2 +1,13 @@
 language: python
-script: python generate_kml.py data/africa.yaml data/america.yaml data/asia.yaml data/australia.yaml data/europe.yaml
+python:
+  - "2.7"
+# command to install dependencies
+install: "pip install -r requirements.txt"
+# command to run tests
+script:
+  - yamllint data/africa.yaml
+  - yamllint data/america.yaml
+  - yamllint data/asia.yaml
+  - yamllint data/australia.yaml
+  - yamllint data/europe.yaml
+  - python generate_kml.py data/africa.yaml data/america.yaml data/asia.yaml data/australia.yaml data/europe.yaml

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,5 @@
+---
+
+extends: relaxed
+rules:
+  line-length: false

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# ROS Map
+___
+### lists all the ROS users arround the globe
 
 Master branch :
 [![Build Status](https://travis-ci.org/prajankya/ros_map.svg?branch=master)](https://travis-ci.org/prajankya/ros_map)  
@@ -6,4 +9,8 @@ Master branch :
 travis branch :
 [![Build Status](https://travis-ci.org/prajankya/ros_map.svg?branch=travis)](https://travis-ci.org/prajankya/ros_map)
 (travis branch is to check the yaml using travis CI). This branch is expected to be merged to master at #DLu/ros_map
+
+
+For doing addition to map, check the README.md in data folder of this repository.
+
 You can see the map at [http://metrorobots.com/rosmap.html](http://metrorobots.com/rosmap.html).

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
+
+Master branch :
+[![Build Status](https://travis-ci.org/prajankya/ros_map.svg?branch=master)](https://travis-ci.org/prajankya/ros_map)  
+
+
+travis branch :
+[![Build Status](https://travis-ci.org/prajankya/ros_map.svg?branch=travis)](https://travis-ci.org/prajankya/ros_map)
+(travis branch is to check the yaml using travis CI). This branch is expected to be merged to master at #DLu/ros_map
 You can see the map at [http://metrorobots.com/rosmap.html](http://metrorobots.com/rosmap.html).

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@ ___
 ### lists all the ROS users arround the globe
 
 Master branch :
-[![Build Status](https://travis-ci.org/prajankya/ros_map.svg?branch=master)](https://travis-ci.org/prajankya/ros_map)  
+[![Build Status](https://travis-ci.org/DLu/ros_map.svg?branch=master)](https://travis-ci.org/DLu/ros_map)
 
 
 travis branch :
-[![Build Status](https://travis-ci.org/prajankya/ros_map.svg?branch=travis)](https://travis-ci.org/prajankya/ros_map)
-(travis branch is to check the yaml using travis CI). This branch is expected to be merged to master at #DLu/ros_map
+[![Build Status](https://travis-ci.org/DLu/ros_map.svg?branch=travis)](https://travis-ci.org/DLu/ros_map)
 
 
 For doing addition to map, check the README.md in data folder of this repository.

--- a/data/africa.yaml
+++ b/data/africa.yaml
@@ -4,4 +4,3 @@
    lat: 35.707902
    long: -0.578986
    link: https://github.com/amineHorseman
-   

--- a/data/europe.yaml
+++ b/data/europe.yaml
@@ -151,7 +151,7 @@
    long: 18.0752322
    lat: 59.3463036
    link: http://wiki.ros.org/kth-ros-pkg
-   address: Teknikringen 14, 114 28 Stockholm, Sweden 
+   address: Teknikringen 14, 114 28 Stockholm, Sweden
  - name: KULeuven Universiteit
    type: school
    long: 4.682986
@@ -367,7 +367,7 @@
    type: company
    description: Service robotics and product development.
    address: Valencia, Spain
-   long: -0.37629 
+   long: -0.37629
    lat: 39.46991
    link: http://www.robotnik.eu
  - name: University Jaume I

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
+yamllint
 pyyaml
 urllib2
-


### PR DESCRIPTION
The yamllint file is used for configuration of yamllint.

Currently the settings are relaxed, but I insist we should go with strict. If you agree, I would PR the patch.