### PR TITLE
Fix Tecnalia's type

### DIFF
--- a/data/europe.yaml
+++ b/data/europe.yaml
@@ -408,7 +408,7 @@
   lat: 48.198716
   long: 16.368586
 - name: Tecnalia
-  type: company
+  type: research institute
   lat: 43.277205
   long: -1.977539
 - name: The Shadow Robot Company


### PR DESCRIPTION
Tecnalia was labelled as a company, but a category that fits better is "research institute".