### PR TITLE
Move RethinkRobotics from US to Germany

### DIFF
--- a/data/america.yaml
+++ b/data/america.yaml
@@ -338,12 +338,6 @@
   long: -113.498983
   address: 10359 104 St NW, Edmonton, AB T5J 1B9
   link: http://rosedmonton.org
-- name: Rethink Robotics
-  type: company
-  lat: 42.34691
-  long: -71.049622
-  address: 27 Wormwood St, Boston, MA, USA 02210
-  link: http://www.rethinkrobotics.com
 - name: Rhoeby Dynamics
   type: company
   lat: 36.969092

--- a/data/europe.yaml
+++ b/data/europe.yaml
@@ -452,6 +452,12 @@
   address: Felix-Wankel-Straße 2, 73760 Ostfildern
   description: The Spirit of Safety
   link: https://www.pilz.com/en-INT/products-solutions/robotics/ros-modules
+- name: Rethink Robotics GmbH
+  type: company
+  lat: 51.477111
+  long: 7.295245
+  address: Industriestraße 38C, 44894 Bochum, Germany
+  link: http://www.rethinkrobotics.com
 - name: RTC Group - University of Seville
   type: school
   lat: 37.381009


### PR DESCRIPTION
Remove RethinkRobotics from the America list and add it with updated info to the Europe list as the company was closed and re-founded in Germany, Europe.