### PR TITLE
Update sources for lat/long information

### DIFF
--- a/data/README.md
+++ b/data/README.md
@@ -12,5 +12,4 @@ You may also add:
  * address
 
 Possible sources for lat/long information are:
- * http://getlatlong.net (enter your location manually)
- * http://locationdetection.mobi/ (use your browser's location)
+ * https://www.latlong.net/ (enter your location manually)


### PR DESCRIPTION
It seems that getlatlong.net does not work anymore, I suggested an alternative.

The locationdetection.mobi seems to have been taken over by some ad websites so I suggest deleting it